### PR TITLE
Update record with ZOOM extended services

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -53,6 +53,31 @@ conn.query = function (type, queryString) {
   return clone;
 };
 
+conn.updateRecord = function(options, cb) {
+
+  if (!options) {
+      throw new Error('No package options given');
+  }
+  
+  var packageOpts = Options_();
+  Object.keys(options)
+    .forEach(function(k) {
+      packageOpts.set(k, options[k])
+    });
+
+  cb || (cb = noop);
+
+  this.connect(function (err) {
+    if (err) {
+      cb(err);
+      return;
+    }
+
+    this._conn.update(packageOpts, cb);
+  }.bind(this));
+  
+}
+
 conn.sort = function () {
   if (!this._query) {
     throw new Error('Query not found');

--- a/src/connection.h
+++ b/src/connection.h
@@ -18,6 +18,7 @@ class Connection : public Nan::ObjectWrap {
         static NAN_METHOD(Connect);
         static NAN_METHOD(Destory);
         static NAN_METHOD(Search);
+        static NAN_METHOD(Update);
 
     protected:
         ZOOM_connection zconn_;
@@ -52,6 +53,23 @@ class SearchWorker : public Nan::AsyncWorker {
         ZOOM_connection zconn_;
         ZOOM_query zquery_;
         ZOOM_resultset zresultset_;
+};
+
+class UpdateWorker : public Nan::AsyncWorker {
+    public:
+        UpdateWorker(Nan::Callback *callback, ZOOM_connection zconn,
+            ZOOM_options options) :
+            Nan::AsyncWorker(callback), zconn_(zconn), zoptions_(options) {};
+        ~UpdateWorker() {};
+        void Execute();
+        void HandleOKCallback();
+        void HandleErrorCallback();
+
+    protected:
+        ZOOM_connection zconn_;
+        ZOOM_options zoptions_;
+        ZOOM_resultset zresultset_;
+        ZOOM_package z_package;
 };
 
 } // namespace node_zoom


### PR DESCRIPTION
Implementation to update records using ZOOM extended services https://software.indexdata.com/yaz/doc/zoom.extendedservices.html

Usage:
```
zoom.connection('host:2100')
  .set('password', 'password123')
  .updateRecord({
    record: marcRecordInISO2709,
    action: "recordInsert"
  }, function (err, data) {
    console.log("Data: " + JSON.stringify(data));
    console.log("Err: " + err);
  });
```