### PR TITLE
feat: expose #connect in connection type definitions

### DIFF
--- a/lib/connection.d.ts
+++ b/lib/connection.d.ts
@@ -34,6 +34,13 @@ export class Connection extends Readable {
   get(key: string): string;
 
   /**
+   * Establishes a connection.
+   *
+   * Note: returned value is actually a clone of the connection.
+   */
+  connect(cb: (error: Error) => void): this;
+
+  /**
    * Prepares search query using specified query type.
    *
    * Note: returned value is actually a clone of the connection.


### PR DESCRIPTION
This is simply to expose the function `connect` in type definitions for a `Connection` object. We have a use case where we need to simply connect without querying.