### PR TITLE
feat(build): update node-gyp bindings to use pkg-config instead of yaz-config

### DIFF
--- a/binding-not-win.gyp
+++ b/binding-not-win.gyp
@@ -2,10 +2,11 @@
   'targets': [
     {
       'target_name': 'zoom',
-      "cflags": ["<!@(yaz-config --libs <!@(if test '4' = <!@(pkg-config --modversion yaz|cut -f1 -d '.');then echo -n '--cflags'; '--include';fi))"],
-      "libraries": ["<!@(yaz-config --libs)"],
+      "cflags": ["<!@(pkg-config --cflags yaz)"],
+      "libraries": ["<!@(pkg-config --libs yaz)"],
       'include_dirs': [
-        '<!(node -e "require(\'nan\')")'
+        "<!(node -e 'require(\"nan\")')",
+        "<!@(pkg-config --cflags-only-I yaz | sed 's/-I//g')"
       ],
       'sources': [
         'src/zoom.cc',


### PR DESCRIPTION
Apparently, the `yaz-config` file is not longer packaged as part of `libyaz-dev` (c.f. version 5.30.0-1 in this change logs : https://metadata.ftp-master.debian.org/changelogs/main/y/yaz/unstable_changelog), so new versions of this lib will cause the node-gyp build to fail because the binding files rely on it.

Rather than using `yaz-config`, it is encouraged to use `pkg-config`.

This has been tested on Mac (with `pkg-config` installed through Homebrew) and on Debian Linux.